### PR TITLE
Fixed Node 10 warning

### DIFF
--- a/tasks/service.coffee
+++ b/tasks/service.coffee
@@ -146,7 +146,7 @@ module.exports = ( grunt ) ->
           log.writeln 'disconnect', arguments
 
       if data.generatePID and data.pidFile
-        fs.writeFile(data.pidFile, proc.pid)
+        fs.writeFileSync(data.pidFile, proc.pid)
 
       if data.pidFile
         loopUntil ()-> 


### PR DESCRIPTION
Node 10 emits a warning when calling writeFile without a callback. This was causing grunt to fail on certain hosts.